### PR TITLE
Fix a typo where sum is defined as average

### DIFF
--- a/99_RelationalAlgebraOverview.ipynb
+++ b/99_RelationalAlgebraOverview.ipynb
@@ -897,7 +897,7 @@
     "* mean -- take the average of a numerical value in a column for all the rows in the group\n",
     "* max -- find the max of a numerical value in a column for all the rows in the group\n",
     "* min -- find the min of a numerical value in a column for all the rows in the group\n",
-    "* sum -- take the average of a numerical value in a column for all the rows in the group\n",
+    "* sum -- find the sum of a numerical value in a column for all the rows in the group\n",
     "* median -- find the median a numerical value in a column for all the rows in the group\n",
     "\n",
     "![](groupby2.png)\n",


### PR DESCRIPTION
Fixed a typo that explains sum as average
